### PR TITLE
Tolerate spaces in the current working directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ bin/$(ARCH)/$(BIN): build-dirs
 	@echo "building: $@"
 	@docker run                                                             \
 	    -ti                                                                 \
- 	    --rm                                                                \
+	    --rm                                                                \
 	    -u $$(id -u):$$(id -g)                                              \
 	    -v "$$(pwd)/.go:/go"                                                \
 	    -v "$$(pwd):/go/src/$(PKG)"                                         \
@@ -131,7 +131,7 @@ version:
 test: build-dirs
 	@docker run                                                             \
 	    -ti                                                                 \
-      --rm                                                                \
+	    --rm                                                                \
 	    -u $$(id -u):$$(id -g)                                              \
 	    -v "$$(pwd)/.go:/go"                                                \
 	    -v "$$(pwd):/go/src/$(PKG)"                                         \

--- a/Makefile
+++ b/Makefile
@@ -80,21 +80,21 @@ build: bin/$(ARCH)/$(BIN)
 
 bin/$(ARCH)/$(BIN): build-dirs
 	@echo "building: $@"
-	@docker run                                                            \
-	    -ti                                                                \
-	    -u $$(id -u):$$(id -g)                                             \
-	    -v $$(pwd)/.go:/go                                                 \
-	    -v $$(pwd):/go/src/$(PKG)                                          \
-	    -v $$(pwd)/bin/$(ARCH):/go/bin                                     \
-	    -v $$(pwd)/bin/$(ARCH):/go/bin/$$(go env GOOS)_$(ARCH)             \
-	    -v $$(pwd)/.go/std/$(ARCH):/usr/local/go/pkg/linux_$(ARCH)_static  \
-	    -w /go/src/$(PKG)                                                  \
-	    $(BUILD_IMAGE)                                                     \
-	    /bin/sh -c "                                                       \
-	        ARCH=$(ARCH)                                                   \
-	        VERSION=$(VERSION)                                             \
-	        PKG=$(PKG)                                                     \
-	        ./build/build.sh                                               \
+	@docker run                                                             \
+	    -ti                                                                 \
+	    -u $$(id -u):$$(id -g)                                              \
+	    -v "$$(pwd)/.go:/go"                                                \
+	    -v "$$(pwd):/go/src/$(PKG)"                                         \
+	    -v "$$(pwd)/bin/$(ARCH):/go/bin"                                    \
+	    -v "$$(pwd)/bin/$(ARCH):/go/bin/$$(go env GOOS)_$(ARCH)"            \
+	    -v "$$(pwd)/.go/std/$(ARCH):/usr/local/go/pkg/linux_$(ARCH)_static" \
+	    -w /go/src/$(PKG)                                                   \
+	    $(BUILD_IMAGE)                                                      \
+	    /bin/sh -c "                                                        \
+	        ARCH=$(ARCH)                                                    \
+	        VERSION=$(VERSION)                                              \
+	        PKG=$(PKG)                                                      \
+	        ./build/build.sh                                                \
 	    "
 
 DOTFILE_IMAGE = $(subst /,_,$(IMAGE))-$(VERSION)
@@ -124,17 +124,17 @@ version:
 	@echo $(VERSION)
 
 test: build-dirs
-	@docker run                                                            \
-	    -ti                                                                \
-	    -u $$(id -u):$$(id -g)                                             \
-	    -v $$(pwd)/.go:/go                                                 \
-	    -v $$(pwd):/go/src/$(PKG)                                          \
-	    -v $$(pwd)/bin/$(ARCH):/go/bin                                     \
-	    -v $$(pwd)/.go/std/$(ARCH):/usr/local/go/pkg/linux_$(ARCH)_static  \
-	    -w /go/src/$(PKG)                                                  \
-	    $(BUILD_IMAGE)                                                     \
-	    /bin/sh -c "                                                       \
-	        ./build/test.sh $(SRC_DIRS)                                    \
+	@docker run                                                             \
+	    -ti                                                                 \
+	    -u $$(id -u):$$(id -g)                                              \
+	    -v "$$(pwd)/.go:/go"                                                \
+	    -v "$$(pwd):/go/src/$(PKG)"                                         \
+	    -v "$$(pwd)/bin/$(ARCH):/go/bin"                                    \
+	    -v "$$(pwd)/.go/std/$(ARCH):/usr/local/go/pkg/linux_$(ARCH)_static" \
+	    -w /go/src/$(PKG)                                                   \
+	    $(BUILD_IMAGE)                                                      \
+	    /bin/sh -c "                                                        \
+	        ./build/test.sh $(SRC_DIRS)                                     \
 	    "
 
 build-dirs:


### PR DESCRIPTION
Addressing #8, when _$(pwd)_ evaluates to a string with spaces, the shell parses the resulting arguments for binding Docker volumes incorrectly. Quote these arguments to supply them indivisibly as intended.
