### PR TITLE
Modifications for multi-binary builds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /bin
 /.go
-/.push-*
-/.container-*
-/.dockerfile-*
+/.*-push
+/.*-container
+/.*-dockerfile

--- a/Dockerfile.app1
+++ b/Dockerfile.app1
@@ -14,7 +14,7 @@
 
 FROM ARG_FROM
 
-MAINTAINER Tim Hockin <thockin@google.com>
+MAINTAINER Bowei Du <bowei@google.com>
 
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
 

--- a/Dockerfile.app2
+++ b/Dockerfile.app2
@@ -1,0 +1,22 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ARG_FROM
+
+MAINTAINER Bowei Du <bowei@google.com>
+
+ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
+
+USER nobody:nobody
+ENTRYPOINT ["/ARG_BIN"]

--- a/Makefile
+++ b/Makefile
@@ -12,139 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The binary to build (just the basename).
-BIN := myapp
+#
+# `make help` will show commonly used targets.
+#
 
-# This repo's root import path (under GOPATH).
-PKG := github.com/thockin/go-build-template
+# Golang package.
+PKG := github.com/bowei/go-build-template
 
-# Where to push the docker image.
-REGISTRY ?= thockin
+# List of binaries to build. You must have a matching Dockerfile.BINARY
+# for each BINARY.
+BINARIES := app1 app2
 
-# Which architecture to build - see $(ALL_ARCH) for options.
+# Registry to push to.
+REGISTRY ?= my-registry
+# Default architecture to build for.
 ARCH ?= amd64
+# Image to use for building.
+BUILD_IMAGE ?= golang:1.7-alpine
+# Containers will be named: $(CONTAINER_PREFIX)-$(BINARY)-$(ARCH):$(VERSION)
+CONTAINER_PREFIX ?= my-prefix
 
 # This version-strategy uses git tags to set the version string
-VERSION := $(shell git describe --tags --always --dirty)
-#
+VERSION ?= $(shell git describe --tags --always --dirty)
 # This version-strategy uses a manual value to set the version string
 #VERSION := 1.2.3
 
-###
-### These variables should not need tweaking.
-###
+# Set to 1 to print more verbose output from the build.
+VERBOSE ?= 0
 
-SRC_DIRS := cmd pkg # directories which hold app source (not vendored)
-
-ALL_ARCH := amd64 arm arm64 ppc64le
-
-# Set default base image dynamically for each arch
-ifeq ($(ARCH),amd64)
-    BASEIMAGE?=alpine
-endif
-ifeq ($(ARCH),arm)
-    BASEIMAGE?=armel/busybox
-endif
-ifeq ($(ARCH),arm64)
-    BASEIMAGE?=aarch64/busybox
-endif
-ifeq ($(ARCH),ppc64le)
-    BASEIMAGE?=ppc64le/busybox
-endif
-
-IMAGE := $(REGISTRY)/$(BIN)-$(ARCH)
-
-BUILD_IMAGE ?= golang:1.7-alpine
-
-# If you want to build all binaries, see the 'all-build' rule.
-# If you want to build all containers, see the 'all-container' rule.
-# If you want to build AND push all containers, see the 'all-push' rule.
-all: build
-
-build-%:
-	@$(MAKE) --no-print-directory ARCH=$* build
-
-container-%:
-	@$(MAKE) --no-print-directory ARCH=$* container
-
-push-%:
-	@$(MAKE) --no-print-directory ARCH=$* push
-
-all-build: $(addprefix build-, $(ALL_ARCH))
-
-all-container: $(addprefix container-, $(ALL_ARCH))
-
-all-push: $(addprefix push-, $(ALL_ARCH))
-
-build: bin/$(ARCH)/$(BIN)
-
-bin/$(ARCH)/$(BIN): build-dirs
-	@echo "building: $@"
-	@docker run                                                            \
-	    -ti                                                                \
-	    -u $$(id -u):$$(id -g)                                             \
-	    -v $$(pwd)/.go:/go                                                 \
-	    -v $$(pwd):/go/src/$(PKG)                                          \
-	    -v $$(pwd)/bin/$(ARCH):/go/bin                                     \
-	    -v $$(pwd)/bin/$(ARCH):/go/bin/linux_$(ARCH)                       \
-	    -v $$(pwd)/.go/std/$(ARCH):/usr/local/go/pkg/linux_$(ARCH)_static  \
-	    -w /go/src/$(PKG)                                                  \
-	    $(BUILD_IMAGE)                                                     \
-	    /bin/sh -c "                                                       \
-	        ARCH=$(ARCH)                                                   \
-	        VERSION=$(VERSION)                                             \
-	        PKG=$(PKG)                                                     \
-	        ./build/build.sh                                               \
-	    "
-
-DOTFILE_IMAGE = $(subst /,_,$(IMAGE))-$(VERSION)
-
-container: .container-$(DOTFILE_IMAGE) container-name
-.container-$(DOTFILE_IMAGE): bin/$(ARCH)/$(BIN) Dockerfile.in
-	@sed \
-	    -e 's|ARG_BIN|$(BIN)|g' \
-	    -e 's|ARG_ARCH|$(ARCH)|g' \
-	    -e 's|ARG_FROM|$(BASEIMAGE)|g' \
-	    Dockerfile.in > .dockerfile-$(ARCH)
-	@docker build -t $(IMAGE):$(VERSION) -f .dockerfile-$(ARCH) .
-	@docker images -q $(IMAGE):$(VERSION) > $@
-
-container-name:
-	@echo "container: $(IMAGE):$(VERSION)"
-
-push: .push-$(DOTFILE_IMAGE) push-name
-.push-$(DOTFILE_IMAGE): .container-$(DOTFILE_IMAGE)
-	@gcloud docker push $(IMAGE):$(VERSION)
-	@docker images -q $(IMAGE):$(VERSION) > $@
-
-push-name:
-	@echo "pushed: $(IMAGE):$(VERSION)"
-
-version:
-	@echo $(VERSION)
-
-test: build-dirs
-	@docker run                                                            \
-	    -ti                                                                \
-	    -u $$(id -u):$$(id -g)                                             \
-	    -v $$(pwd)/.go:/go                                                 \
-	    -v $$(pwd):/go/src/$(PKG)                                          \
-	    -v $$(pwd)/bin/$(ARCH):/go/bin                                     \
-	    -v $$(pwd)/.go/std/$(ARCH):/usr/local/go/pkg/linux_$(ARCH)_static  \
-	    -w /go/src/$(PKG)                                                  \
-	    $(BUILD_IMAGE)                                                     \
-	    /bin/sh -c "                                                       \
-	        ./build/test.sh $(SRC_DIRS)                                    \
-	    "
-
-build-dirs:
-	@mkdir -p bin/$(ARCH)
-	@mkdir -p .go/src/$(PKG) .go/pkg .go/bin .go/std/$(ARCH)
-
-clean: container-clean bin-clean
-
-container-clean:
-	rm -rf .container-* .dockerfile-* .push-*
-
-bin-clean:
-	rm -rf .go bin
+# Include standard build rules.
+include rules.mk

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ PKG := github.com/bowei/go-build-template
 # List of binaries to build. You must have a matching Dockerfile.BINARY
 # for each BINARY.
 BINARIES := app1 app2
+# List of additional images to build. These are located in the images/
+# directory.
+IMAGES := hello
 
 # Registry to push to.
 REGISTRY ?= my-registry

--- a/README.md
+++ b/README.md
@@ -11,29 +11,30 @@ This has only been tested on Linux, and depends on Docker to build.
 To use this, simply copy these files and make the following changes:
 
 Makefile:
-   - change `BIN` to your binary name
+   - change `BINARIES` to list your binaries
    - change `PKG` to the Go import path of this repo
    - change `REGISTRY` to the Docker registry you want to use
-   - maybe change `SRC_DIRS` if you use some other layout
    - choose a strategy for `VERSION` values - git tags or manual
 
-Dockerfile.in:
+Dockerfile.BINARY:
    - change the `MAINTAINER` to you
    - maybe change or remove the `USER` if you need
 
 ## Building
 
-Run `make` or `make build` to compile your app.  This will use a Docker image
-to build your app, with the current directory volume-mounted into place.  This
-will store incremental state for the fastest possible build.  Run `make
-all-build` to build for all architectures.
+Run `make` or `make build` to compile your app.  This will use a Docker image to
+build your app, with the current directory volume-mounted into place.  This will
+store incremental state for the fastest possible build.  Run `make all-build` to
+build for all architectures.
 
-Run `make container` to build the container image.  It will calculate the image
-tag based on the most recent git tag, and whether the repo is "dirty" since
-that tag (see `make version`).  Run `make all-container` to build containers
-for all architectures.
+Run `make containers` to build the container image.  It will calculate the image
+tag based on the most recent git tag, and whether the repo is "dirty" since that
+tag (see `make version`).  Run `make all-containers` to build containers for all
+architectures.
 
-Run `make push` to push the container image to `REGISTRY`.  Run `make all-push`
+Run `make push` to push the container images to `REGISTRY`.  Run `make all-push`
 to push the container images for all architectures.
 
 Run `make clean` to clean up.
+
+See `make help` for more details.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Additional images
   `images/` directory. See [`images/Makefile`](images/Makefile) for more
   details.
 
-
 ## Building
 
 Run `make` or `make build` to compile your app.  This will use a Docker image to

--- a/README.md
+++ b/README.md
@@ -11,14 +11,20 @@ This has only been tested on Linux, and depends on Docker to build.
 To use this, simply copy these files and make the following changes:
 
 Makefile:
-   - change `BINARIES` to list your binaries
-   - change `PKG` to the Go import path of this repo
-   - change `REGISTRY` to the Docker registry you want to use
-   - choose a strategy for `VERSION` values - git tags or manual
+- change `BINARIES` to list your binaries
+- change `PKG` to the Go import path of this repo
+- change `REGISTRY` to the Docker registry you want to use
+- choose a strategy for `VERSION` values - git tags or manual
 
 Dockerfile.BINARY:
-   - change the `MAINTAINER` to you
-   - maybe change or remove the `USER` if you need
+- change the `MAINTAINER` to you
+- maybe change or remove the `USER` if you need
+
+Additional images
+- Additional images to be build should be listed in `IMAGES` and placed in the
+  `images/` directory. See [`images/Makefile`](images/Makefile) for more
+  details.
+
 
 ## Building
 

--- a/cmd/app1/main.go
+++ b/cmd/app1/main.go
@@ -16,8 +16,5 @@ limitations under the License.
 
 package main
 
-import "log"
-
 func main() {
-	log.Printf("hello, world!")
 }

--- a/cmd/app2/main.go
+++ b/cmd/app2/main.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+func main() {
+}

--- a/images/Makefile
+++ b/images/Makefile
@@ -1,0 +1,69 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Each image/ Makefile MUST provide the following targets:
+#
+# build      : build the source code
+# containers : create the Docker containers
+# test       : test the containers
+# push       : push the containers to the registry
+#
+# The following variables are exported to the submake process:
+#
+# REGISTRY : registry to push to
+# ARCH     : architecture to build
+# CONTAINER_PREFIX: prefix for container names
+# VERSION  : version, e.g. tag for the containers
+# VERBOSE  : will be 1 if running in verbose mode
+
+# List of image directories to build.
+IMAGES ?=
+
+all: build
+
+.PHONY: build
+build:
+	@$(MAKE) $(addprefix build-,$(IMAGES))
+
+.PHONY: containers
+containers:
+	@$(MAKE) $(addprefix containers-,$(IMAGES))
+
+.PHONY: push
+push:
+	@$(MAKE) $(addprefix push-,$(IMAGES))
+
+.PHONY: test
+test:
+	@$(MAKE) $(addprefix test-,$(IMAGES))
+
+.PHONY: clean
+clean:
+	@$(MAKE) $(addprefix clean-,$(IMAGES))
+
+# Suffix rules to dispatch to the appropriate subdirectory.
+build-%:
+	@$(MAKE) -C $* build
+
+containers-%:
+	@$(MAKE) -C $* containers
+
+push-%:
+	@$(MAKE) -C $* push
+
+test-%:
+	@$(MAKE) -C $* test
+
+clean-%:
+	@$(MAKE) -C $* clean

--- a/images/hello/.gitignore
+++ b/images/hello/.gitignore
@@ -1,0 +1,3 @@
+/_output/
+.*-container
+.*-push

--- a/images/hello/Dockerfile.in
+++ b/images/hello/Dockerfile.in
@@ -1,0 +1,4 @@
+FROM alpine
+MAINTAINER Bowei Du <bowei@google.com>
+
+COPY _output/__ARCH__/hello /hello

--- a/images/hello/Makefile
+++ b/images/hello/Makefile
@@ -1,0 +1,59 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+REGISTRY ?= my-registry
+ARCH ?= amd64
+CONTAINER_PREFIX ?= my-prefix
+VERSION ?= 1.0.0
+
+BINARY := hello
+OUTPUT_DIR := _output/$(ARCH)
+IMAGE := $(REGISTRY)/$(BINARY)-$(ARCH)
+STAMP := $(subst /,_,$(IMAGE))
+CONTAINER_STAMP := .$(STAMP)-container
+PUSH_STAMP := .$(STAMP)-push
+
+all: build
+
+.PHONY: build
+build: $(OUTPUT_DIR)/hello
+
+$(OUTPUT_DIR)/hello: hello.c
+	@mkdir -p $(@D)
+	gcc -o $@ -O3 hello.c
+
+.PHONY: containers
+containers: $(CONTAINER_STAMP)
+
+$(CONTAINER_STAMP): $(OUTPUT_DIR)/$(BINARY)
+	sed 's|__ARCH__|$(ARCH)|g' Dockerfile.in > $(OUTPUT_DIR)/Dockerfile
+	docker build -q -t $(IMAGE):$(VERSION) -f $(OUTPUT_DIR)/Dockerfile . > $@
+
+.PHONY: push
+push: $(PUSH_STAMP)
+
+$(PUSH_STAMP): $(CONTAINER_STAMP)
+	docker push $(IMAGE):$(VERSION)
+	@cat $(CONTAINER_STAMP) > $@
+
+.PHONY: test
+test: build
+	@$(OUTPUT_DIR)/hello
+
+.PHONY: clean
+clean:
+	rm -rf $(OUTPUT_DIR)
+	rm -f .*-container
+	rm -f .*-push

--- a/images/hello/hello.c
+++ b/images/hello/hello.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(int argc, char* argv[]) {
+  printf("hello, world!\n");
+  return 0;
+}

--- a/rules.mk
+++ b/rules.mk
@@ -1,0 +1,201 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# These build rules should not need to be modified.
+#
+SRC_DIRS := cmd pkg # directories which hold app source (not vendored)
+
+ALL_ARCH := amd64 arm arm64 ppc64le
+# Set default base image dynamically for each arch
+ifeq ($(ARCH),amd64)
+    BASEIMAGE?=alpine
+endif
+ifeq ($(ARCH),arm)
+    BASEIMAGE?=armel/busybox
+endif
+ifeq ($(ARCH),arm64)
+    BASEIMAGE?=aarch64/busybox
+endif
+ifeq ($(ARCH),ppc64le)
+    BASEIMAGE?=ppc64le/busybox
+endif
+
+# These rules MUST be expanded at reference time (hence '=') as BINARY
+# is dynamically scoped.
+CONTAINER_NAME  = $(REGISTRY)/$(CONTAINER_PREFIX)-$(BINARY)-$(ARCH)
+BUILDSTAMP_NAME = $(subst /,_,$(CONTAINER_NAME))
+
+GO_BINARIES := $(addprefix bin/$(ARCH)/,$(BINARIES))
+CONTAINER_BUILDSTAMPS := $(foreach BINARY,$(BINARIES),.$(BUILDSTAMP_NAME)-container)
+PUSH_BUILDSTAMPS := $(foreach BINARY,$(BINARIES),.$(BUILDSTAMP_NAME)-push)
+
+ifeq ($(VERBOSE), 1)
+	DOCKER_BUILD_FLAGS :=
+	VERBOSE_OUTPUT := >&1
+else
+	DOCKER_BUILD_FLAGS := -q
+	VERBOSE_OUTPUT := >/dev/null
+endif
+
+all: build
+
+build-%:
+	@$(MAKE) --no-print-directory ARCH=$* build
+
+containers-%:
+	@$(MAKE) --no-print-directory ARCH=$* containers
+
+push-%:
+	@$(MAKE) --no-print-directory ARCH=$* push
+
+
+.PHONY: all-build
+all-build: $(addprefix build-, $(ALL_ARCH))
+
+.PHONY: all-containers
+all-containers: $(addprefix containers-, $(ALL_ARCH))
+
+.PHONY: all-push
+all-push: $(addprefix push-, $(ALL_ARCH))
+
+.PHONY: build
+build: $(GO_BINARIES)
+
+
+# Rule for all bin/$(ARCH)/bin/$(BINARY)
+$(GO_BINARIES): build-dirs
+	@echo "building : $@"
+	@docker run                                                            \
+	    --sig-proxy=true                                                   \
+	    -u $$(id -u):$$(id -g)                                             \
+	    -v $$(pwd)/.go:/go                                                 \
+	    -v $$(pwd):/go/src/$(PKG)                                          \
+	    -v $$(pwd)/bin/$(ARCH):/go/bin                                     \
+	    -v $$(pwd)/bin/$(ARCH):/go/bin/linux_$(ARCH)                       \
+	    -v $$(pwd)/.go/std/$(ARCH):/usr/local/go/pkg/linux_$(ARCH)_static  \
+	    -w /go/src/$(PKG)                                                  \
+	    $(BUILD_IMAGE)                                                     \
+	    /bin/sh -c "                                                       \
+	        ARCH=$(ARCH)                                                   \
+	        VERSION=$(VERSION)                                             \
+	        PKG=$(PKG)                                                     \
+	        ./build/build.sh                                               \
+	    "
+
+
+# Rules for dockerfiles.
+define DOCKERFILE_RULE
+.$(BINARY)-$(ARCH)-dockerfile: Dockerfile.$(BINARY)
+	@echo generating Dockerfile $$@ from $$<
+	@sed					\
+	    -e 's|ARG_BIN|$(BINARY)|g'		\
+	    -e 's|ARG_ARCH|$(ARCH)|g'		\
+	    -e 's|ARG_FROM|$(BASEIMAGE)|g'	\
+	    $$< > $$@
+.$(BUILDSTAMP_NAME)-container: .$(BINARY)-$(ARCH)-dockerfile
+endef
+$(foreach BINARY,$(BINARIES),$(eval $(DOCKERFILE_RULE)))
+
+
+# Rules for containers
+define CONTAINER_RULE
+.$(BUILDSTAMP_NAME)-container: bin/$(ARCH)/$(BINARY)
+	@echo "container: bin/$(ARCH)/$(BINARY) ($(CONTAINER_NAME))"
+	@docker build					\
+		$(DOCKER_BUILD_FLAGS)			\
+		-t $(CONTAINER_NAME):$(VERSION)		\
+		-f .$(BINARY)-$(ARCH)-dockerfile .	\
+		$(VERBOSE_OUTPUT)
+	@echo "$(CONTAINER_NAME):$(VERSION)" > $$@
+	@docker images -q $(CONTAINER_NAME):$(VERSION) >> $$@
+endef
+$(foreach BINARY,$(BINARIES),$(eval $(CONTAINER_RULE)))
+
+.PHONY: containers
+containers: $(CONTAINER_BUILDSTAMPS)
+
+
+# Rules for pushing
+.PHONY: push
+push: $(PUSH_BUILDSTAMPS)
+
+.%-push: .%-container
+	@echo "pushing  :" $$(head -n 1 $<)
+	@gcloud docker -- push $$(head -n 1 $<) $(VERBOSE_OUTPUT)
+	@cat $< > $@
+
+define PUSH_RULE
+only-push-$(BINARY): .$(BUILDSTAMP_NAME)-push
+endef
+$(foreach BINARY,$(BINARIES),$(eval $(PUSH_RULE)))
+
+
+# Rule for `test`
+.PHONY: test
+test: build-dirs
+	@docker run                                                            \
+	    --sig-proxy=true                                                   \
+	    -u $$(id -u):$$(id -g)                                             \
+	    -v $$(pwd)/.go:/go                                                 \
+	    -v $$(pwd):/go/src/$(PKG)                                          \
+	    -v $$(pwd)/bin/$(ARCH):/go/bin                                     \
+	    -v $$(pwd)/.go/std/$(ARCH):/usr/local/go/pkg/linux_$(ARCH)_static  \
+	    -w /go/src/$(PKG)                                                  \
+	    $(BUILD_IMAGE)                                                     \
+	    /bin/sh -c "                                                       \
+	        ./build/test.sh $(SRC_DIRS)                                    \
+	    "
+
+# Miscellaneous rules
+.PHONY: version
+version:
+	@echo $(VERSION)
+
+.PHONY: build-dirs
+build-dirs:
+	@mkdir -p bin/$(ARCH)
+	@mkdir -p .go/src/$(PKG) .go/pkg .go/bin .go/std/$(ARCH)
+
+.PHONY: clean
+clean: container-clean bin-clean
+
+.PHONY: container-clean
+container-clean:
+	rm -f .*-container .*-dockerfile .*-push
+
+.PHONY: bin-clean
+bin-clean:
+	rm -rf .go bin
+
+.PHONY: help
+help:
+	@echo "make targets"
+	@echo
+	@echo "  all, build    build all binaries"
+	@echo "  containers    build the containers"
+	@echo "  push          push containers to the registry"
+	@echo "  help          this help message"
+	@echo "  version       show package version"
+	@echo
+	@echo "  {build,containers,push}-ARCH    do action for specific ARCH"
+	@echo "  all-{build,containers,push}     do action for all ARCH"
+	@echo "  only-push-BINARY                push just BINARY"
+	@echo
+	@echo "  Available ARCH: $(ALL_ARCH)"
+	@echo "  Available BINARIES: $(BINARIES)"
+	@echo
+	@echo "  Setting VERBOSE=1 will show additional build logging."
+	@echo
+	@echo "  Setting VERSION will override the container version tag."


### PR DESCRIPTION
- encapsulate the unmodified build logic into a separate file
- make -j should work (does not allocate TTY)