### PR TITLE
Upgrade build image to golang 1.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ endif
 
 IMAGE := $(REGISTRY)/$(BIN)-$(ARCH)
 
-BUILD_IMAGE ?= golang:1.8-alpine
+BUILD_IMAGE ?= golang:1.9-alpine
 
 # If you want to build all binaries, see the 'all-build' rule.
 # If you want to build all containers, see the 'all-container' rule.


### PR DESCRIPTION
This PR updates the `Makefile` to now use [golang:1.9-alpine](https://hub.docker.com/_/golang/).