### PR TITLE
Help Target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 services:
   - docker
 script:
-- make | awk '{print $1}' | grep clean
+- make help | awk '{print $1}' | grep clean
 - make build
 - test -f bin/amd64/myapp
 - make container

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 services:
   - docker
 script:
+- make | awk '{print $1}' | grep clean
 - make build
 - test -f bin/amd64/myapp
 - make container

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,8 @@ BUILD_IMAGE ?= golang:1.9-alpine
 # If you want to build all binaries, see the 'all-build' rule.
 # If you want to build all containers, see the 'all-container' rule.
 # If you want to build AND push all containers, see the 'all-push' rule.
-all: build ## executes the build target
+all: # @HELP executes the build target
+all: build
 
 build-%:
 	@$(MAKE) --no-print-directory ARCH=$* build
@@ -70,13 +71,17 @@ container-%:
 push-%:
 	@$(MAKE) --no-print-directory ARCH=$* push
 
-all-build: $(addprefix build-, $(ALL_ARCH)) ## builds binaries for all architectures
+all-build: # @HELP builds binaries for all architectures
+all-build: $(addprefix build-, $(ALL_ARCH)) 
 
-all-container: $(addprefix container-, $(ALL_ARCH))  ## builds containers for all architectures 
+all-container: # @HELP builds containers for all architectures 
+all-container: $(addprefix container-, $(ALL_ARCH))
 
-all-push: $(addprefix push-, $(ALL_ARCH)) ## pushes containers to registry for all architectures
+all-push: # @HELP pushes containers to defined registry for all architectures
+all-push: $(addprefix push-, $(ALL_ARCH))
 
-build: bin/$(ARCH)/$(BIN) ## builds binary for preferred architecture
+build: # @HELP builds binary for preferred architecture
+build: bin/$(ARCH)/$(BIN) 
 
 bin/$(ARCH)/$(BIN): build-dirs
 	@echo "building: $@"
@@ -99,7 +104,8 @@ bin/$(ARCH)/$(BIN): build-dirs
 	    "
 
 # Example: make shell CMD="-c 'date > datefile'"
-shell: build-dirs  ## launches a shell in the containerized build environment
+shell: # @HELP launches a shell in the containerized build environment
+shell: build-dirs 
 	@echo "launching a shell in the containerized build environment"
 	@docker run                                                             \
 	    -ti                                                                 \
@@ -116,7 +122,8 @@ shell: build-dirs  ## launches a shell in the containerized build environment
 
 DOTFILE_IMAGE = $(subst :,_,$(subst /,_,$(IMAGE))-$(VERSION))
 
-container: .container-$(DOTFILE_IMAGE) container-name  ## builds container for the preferred architecture
+container: # @HELP builds container for the preferred architecture
+container: .container-$(DOTFILE_IMAGE) container-name
 .container-$(DOTFILE_IMAGE): bin/$(ARCH)/$(BIN) Dockerfile.in
 	@sed \
 	    -e 's|ARG_BIN|$(BIN)|g' \
@@ -126,10 +133,12 @@ container: .container-$(DOTFILE_IMAGE) container-name  ## builds container for t
 	@docker build -t $(IMAGE):$(VERSION) -f .dockerfile-$(ARCH) .
 	@docker images -q $(IMAGE):$(VERSION) > $@
 
-container-name:  ## outputs container name
+container-name: # @HELP outputs container name
+container-name:
 	@echo "container: $(IMAGE):$(VERSION)"
 
-push: .push-$(DOTFILE_IMAGE) push-name  ## pushes preferred image to the defined registry
+push: # @HELP pushes preferred image to the defined registry
+push: .push-$(DOTFILE_IMAGE) push-name
 .push-$(DOTFILE_IMAGE): .container-$(DOTFILE_IMAGE)
 ifeq ($(findstring gcr.io,$(REGISTRY)),gcr.io)
 	@gcloud docker -- push $(IMAGE):$(VERSION)
@@ -141,10 +150,12 @@ endif
 push-name:
 	@echo "pushed: $(IMAGE):$(VERSION)"
 
-version:  ## outputs version
+version: # @HELP outputs version
+version:
 	@echo $(VERSION)
 
-test: build-dirs ## executes the test.sh script located in the build directory
+test: # @HELP executes the test.sh script located in the build directory
+test: build-dirs 
 	@docker run                                                             \
 	    -ti                                                                 \
 	    --rm                                                                \
@@ -163,7 +174,8 @@ build-dirs:
 	@mkdir -p bin/$(ARCH)
 	@mkdir -p .go/src/$(PKG) .go/pkg .go/bin .go/std/$(ARCH)
 
-clean: container-clean bin-clean  ## cleans the repository's temporary files
+clean: # @HELP cleans the repository's temporary files
+clean: container-clean bin-clean 
 
 container-clean:
 	rm -rf .container-* .dockerfile-* .push-*
@@ -172,6 +184,9 @@ bin-clean:
 	rm -rf .go bin
 
 help:
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
-
-.DEFAULT_GOAL := help
+	@grep -E '^[a-zA-Z_-]+:.*?# @HELP .*$$' $(MAKEFILE_LIST) \
+    | sort \
+    | awk ' \
+        BEGIN {FS = ":.*?# @HELP "}; \
+        {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}; \
+    '

--- a/Makefile
+++ b/Makefile
@@ -184,9 +184,9 @@ bin-clean:
 	rm -rf .go bin
 
 help:
-	@grep -E '^[a-zA-Z_-]+:.*?# @HELP .*$$' $(MAKEFILE_LIST) \
+	@grep -E '^.*: *# *@HELP' $(MAKEFILE_LIST) \
     | sort \
     | awk ' \
-        BEGIN {FS = ":.*?# @HELP "}; \
+        BEGIN {FS = ": *# *@HELP"}; \
         {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}; \
     '

--- a/README.md
+++ b/README.md
@@ -39,3 +39,5 @@ Run `make push` to push the container image to `REGISTRY`.  Run `make all-push`
 to push the container images for all architectures.
 
 Run `make clean` to clean up.
+
+Run `make help` to get a list of available targets.


### PR DESCRIPTION
add a help target, autogenerated from comments against the other targets, make it the default target. 

Example output 

```
$ make
all-build                      builds binaries for all architectures
all-container                  builds containers for all architectures
all-push                       pushes containers to registry for all architectures
all                            executes the build target
build                          builds binary for preferred architecture
clean                          cleans the repository's temporary files
container-name                 outputs container name
container                      builds container for the preferred architecture
push                           pushes preferred image to the defined registry
shell                          launches a shell in the containerized build environment
test                           executes the test.sh script located in the build directory
version                        outputs version
```
