### PR TITLE
Explicitly require Bash in build/ scripts

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Copyright 2016 The Kubernetes Authors.
 #

--- a/build/test.sh
+++ b/build/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Copyright 2016 The Kubernetes Authors.
 #


### PR DESCRIPTION
The scripts under the `build/` directory use Bash-specific syntax while the
shebang points to `/bin/sh`. This is a problem when BUILD_IMAGE points to an
image like `golang:1.9` which is based on Debian and `/bin/sh` is DASH causing
the build script to fail.