### PR TITLE
Simplify push target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /bin
 /.go
-/.push-*
 /.container-*
 /.dockerfile-*

--- a/Makefile
+++ b/Makefile
@@ -150,8 +150,7 @@ container: .container-$(DOTFILE_IMAGE) say_container_name
 say_container_name:
 	@echo "container: $(IMAGE):$(TAG)"
 
-push: .push-$(DOTFILE_IMAGE) say_push_name
-.push-$(DOTFILE_IMAGE): .container-$(DOTFILE_IMAGE)
+push: .container-$(DOTFILE_IMAGE) say_push_name
 	@docker push $(IMAGE):$(TAG)
 
 say_push_name:
@@ -196,7 +195,7 @@ $(BUILD_DIRS):
 clean: container-clean bin-clean
 
 container-clean:
-	rm -rf .container-* .dockerfile-* .push-*
+	rm -rf .container-* .dockerfile-*
 
 bin-clean:
 	rm -rf .go bin


### PR DESCRIPTION
We always want to try to push because the user may change the target
container registry. Container registries cache image layers, so if the
image has already been pushed, it will be a no-op.