### PR TITLE
An implementation for delivering multiple binaries within the same project

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ This has only been tested on Linux, and depends on Docker to build.
 To use this, simply copy these files and make the following changes:
 
 Makefile:
-   - change `BIN` to your binary name
-   - rename `cmd/myapp` to `cmd/$BIN`
+   - change `BINS` to your binary names
    - change `REGISTRY` to the Docker registry you want to use
    - maybe change `SRC_DIRS` if you use some other layout
    - choose a strategy for `VERSION` values - git tags or manual

--- a/cmd/myotherapp/main.go
+++ b/cmd/myotherapp/main.go
@@ -19,5 +19,5 @@ package main
 import "log"
 
 func main() {
-	log.Printf("myapp: hello, world!")
+	log.Printf("myotherapp: hello, world!")
 }


### PR DESCRIPTION
I made this for folks who want to have the option of delivering multiple binaries from within their go project. The usage remains largely the same. Where you would specify the `BIN` variable, instead you'd put the space delimited list of all the named binaries you intend to build.

If you want to build a subset of your list of deliverables, you just override the `BINS` variable. Say you have two deliverables: `myapp` and `myotherapp`. To build only one with this Makefile, you'd just specify `make BINS=myotherapp`.