### PR TITLE
fix cache folder mount path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ go-build: $(BUILD_DIRS)
 	    -w /src                                                 \
 	    -v $$(pwd)/.go/bin/$(OS)_$(ARCH):/go/bin                \
 	    -v $$(pwd)/.go/bin/$(OS)_$(ARCH):/go/bin/$(OS)_$(ARCH)  \
-	    -v $$(pwd)/.go/cache:/root/.cache/go-build              \
+	    -v $$(pwd)/.go/cache:/root/.cache                       \
 	    --env HTTP_PROXY=$(HTTP_PROXY)                          \
 	    --env HTTPS_PROXY=$(HTTPS_PROXY)                        \
 	    $(BUILD_IMAGE)                                          \
@@ -154,7 +154,7 @@ shell: $(BUILD_DIRS)
 	    -w /src                                                 \
 	    -v $$(pwd)/.go/bin/$(OS)_$(ARCH):/go/bin                \
 	    -v $$(pwd)/.go/bin/$(OS)_$(ARCH):/go/bin/$(OS)_$(ARCH)  \
-	    -v $$(pwd)/.go/cache:/root/.cache/go-build              \
+	    -v $$(pwd)/.go/cache:/root/.cache                       \
 	    --env HTTP_PROXY=$(HTTP_PROXY)                          \
 	    --env HTTPS_PROXY=$(HTTPS_PROXY)                        \
 	    $(BUILD_IMAGE)                                          \
@@ -221,7 +221,7 @@ test: $(BUILD_DIRS)
 	    -w /src                                                 \
 	    -v $$(pwd)/.go/bin/$(OS)_$(ARCH):/go/bin                \
 	    -v $$(pwd)/.go/bin/$(OS)_$(ARCH):/go/bin/$(OS)_$(ARCH)  \
-	    -v $$(pwd)/.go/cache:/root/.cache/go-build              \
+	    -v $$(pwd)/.go/cache:/root/.cache                       \
 	    --env HTTP_PROXY=$(HTTP_PROXY)                          \
 	    --env HTTPS_PROXY=$(HTTPS_PROXY)                        \
 	    $(BUILD_IMAGE)                                          \

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ go-build: $(BUILD_DIRS)
 	    -w /src                                                 \
 	    -v $$(pwd)/.go/bin/$(OS)_$(ARCH):/go/bin                \
 	    -v $$(pwd)/.go/bin/$(OS)_$(ARCH):/go/bin/$(OS)_$(ARCH)  \
-	    -v $$(pwd)/.go/cache:/.cache                            \
+	    -v $$(pwd)/.go/cache:/root/.cache/go-build              \
 	    --env HTTP_PROXY=$(HTTP_PROXY)                          \
 	    --env HTTPS_PROXY=$(HTTPS_PROXY)                        \
 	    $(BUILD_IMAGE)                                          \
@@ -154,7 +154,7 @@ shell: $(BUILD_DIRS)
 	    -w /src                                                 \
 	    -v $$(pwd)/.go/bin/$(OS)_$(ARCH):/go/bin                \
 	    -v $$(pwd)/.go/bin/$(OS)_$(ARCH):/go/bin/$(OS)_$(ARCH)  \
-	    -v $$(pwd)/.go/cache:/.cache                            \
+	    -v $$(pwd)/.go/cache:/root/.cache/go-build              \
 	    --env HTTP_PROXY=$(HTTP_PROXY)                          \
 	    --env HTTPS_PROXY=$(HTTPS_PROXY)                        \
 	    $(BUILD_IMAGE)                                          \
@@ -221,7 +221,7 @@ test: $(BUILD_DIRS)
 	    -w /src                                                 \
 	    -v $$(pwd)/.go/bin/$(OS)_$(ARCH):/go/bin                \
 	    -v $$(pwd)/.go/bin/$(OS)_$(ARCH):/go/bin/$(OS)_$(ARCH)  \
-	    -v $$(pwd)/.go/cache:/.cache                            \
+	    -v $$(pwd)/.go/cache:/root/.cache/go-build              \
 	    --env HTTP_PROXY=$(HTTP_PROXY)                          \
 	    --env HTTPS_PROXY=$(HTTPS_PROXY)                        \
 	    $(BUILD_IMAGE)                                          \


### PR DESCRIPTION
The cache folder mount path doesn't match the GOCACHE environment variable in the docker builder, so currently it can't reuse the go cache to speed up incremental builds.
```
# docker run --rm golang:1.14.1-alpine go env GOCACHE
/root/.cache/go-build
```


