### PR TITLE
Github Action should use the same lint command as local

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,39 +4,17 @@ on: [ push, pull_request ]
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-versions: [ 1.16.x, 1.17.x, 1.18.x, 1.19.x ]
+        platform: [ ubuntu-latest, windows-latest ]
+    runs-on: ${{ matrix.platform }}
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Lint
-        uses: golangci/golangci-lint-action@v2
-        with:
-          # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: latest
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
-
-          # golangci-lint command line arguments.
-          args:
-                -v
-                --max-same-issues 10
-                --disable-all
-                --exclude-use-default=false
-                -E asciicheck
-                -E deadcode
-                -E errcheck
-                -E forcetypeassert
-                -E gocritic
-                -E gofmt
-                -E goimports
-                -E gosimple
-                -E govet
-                -E ineffassign
-                -E misspell
-                -E revive
-                -E staticcheck
-                -E structcheck
-                -E typecheck
-                -E unused
-                -E varcheck
+      - name: Lint code
+        run: make lint


### PR DESCRIPTION
Fixes https://github.com/thockin/go-build-template/issues/69

The nice thing of having a `make lint` is it runs tasks in docker container that works in any environment. We do not need to maintain multiple lint settings in multiple files and we can reuse the same `make lint`.