### PR TITLE
Git creds is required to pull in private repos

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,6 +16,11 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
       uses: actions/checkout@v2
+    - uses: extractions/netrc@v1
+        with:
+          machine: github.com
+          username: rzp
+          password: ${{ secrets.GIT_TOKEN }}
     - name: Build
       run: go build -v ./...
     - name: Test

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /.dockerfile-*
 /.licenses
 /.buildx-initialized
+
+# ide
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,7 @@ go-build: | $(BUILD_DIRS)
 	    -v $$(pwd)/.go/bin/$(OS)_$(ARCH):/go/bin/$(OS)_$(ARCH)  \
 	    -v $$(pwd)/.go/cache:/.cache                            \
 	    -v $$(pwd)/.go/pkg:/go/pkg                              \
+		-v $${HOME}/.netrc:/.netrc                              \
 	    --env ARCH=$(ARCH)                                      \
 	    --env OS=$(OS)                                          \
 	    --env VERSION=$(VERSION)                                \
@@ -194,6 +195,7 @@ shell: | $(BUILD_DIRS)
 	    -v $$(pwd)/.go/bin/$(OS)_$(ARCH):/go/bin/$(OS)_$(ARCH)  \
 	    -v $$(pwd)/.go/cache:/.cache                            \
 	    -v $$(pwd)/.go/pkg:/go/pkg                              \
+		-v $${HOME}/.netrc:/.netrc                              \
 	    --env ARCH=$(ARCH)                                      \
 	    --env OS=$(OS)                                          \
 	    --env VERSION=$(VERSION)                                \
@@ -307,6 +309,7 @@ test: | $(BUILD_DIRS)
 	    -v $$(pwd)/.go/bin/$(OS)_$(ARCH):/go/bin/$(OS)_$(ARCH)  \
 	    -v $$(pwd)/.go/cache:/.cache                            \
 	    -v $$(pwd)/.go/pkg:/go/pkg                              \
+		-v $${HOME}/.netrc:/.netrc                              \
 	    --env ARCH=$(ARCH)                                      \
 	    --env OS=$(OS)                                          \
 	    --env VERSION=$(VERSION)                                \
@@ -329,6 +332,7 @@ lint: | $(BUILD_DIRS)
 	    -v $$(pwd)/.go/bin/$(OS)_$(ARCH):/go/bin/$(OS)_$(ARCH)  \
 	    -v $$(pwd)/.go/cache:/.cache                            \
 	    -v $$(pwd)/.go/pkg:/go/pkg                              \
+		-v $${HOME}/.netrc:/.netrc                              \
 	    --env ARCH=$(ARCH)                                      \
 	    --env OS=$(OS)                                          \
 	    --env VERSION=$(VERSION)                                \


### PR DESCRIPTION
Fixes #68 

`~/.netrc` file present is required to be present in local machine and needs to be mounted in `docker run` for containers to be able to pull private repos

Only passing `GOPRIVATE=org` won't work 

## Usage after this for local:
- Create `~/.netrc` file in ur machine with format:
```
machine github.com
login thockin
password XX
```

- `GOPRIVATE=thockin make build`

## Usage after this for ci/GitHub action:
- Export GIT_TOKEN in the github action

- Now, this will work from Github Action
```

GOPRIVATE=thockin make build
```

Showing sample usage. Based on discussion will fix the PR.

Would like to take #71 first and then update this PR and take it.