### PR TITLE
Update GitHub workflows to run on Go 1.19 and 1.20

### DIFF
--- a/.github/workflows/crossbuild.yaml
+++ b/.github/workflows/crossbuild.yaml
@@ -6,7 +6,7 @@ jobs:
   crossbuild:
     strategy:
       matrix:
-        go-version: [ "1.17", "1.18", "1.19" ]
+        go-version: [ "1.19", "1.20" ]
         platform: [ "ubuntu-latest" ]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ "1.17", "1.18", "1.19" ]
+        go-version: [ "1.19", "1.20" ]
         platform: [ "ubuntu-latest" ]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
Go 1.17 and 1.18 already reached end-of-life.