### PR TITLE
Create "publish" GitHub workflow to publish to GHCR on new releases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,15 +15,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build and push Docker image
-        run: make manifest-list
+        run: make login manifest-list
         env:
           REGISTRY: ghcr.io/${{ github.repository }}
           REGISTRY_USERNAME: ${{ github.actor }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,30 @@
+name: Create and publish image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        run: make manifest-list
+        env:
+          REGISTRY: ghcr.io/${{ github.repository }}
+          REGISTRY_USERNAME: ${{ github.actor }}
+          REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -307,6 +307,11 @@ $(CONTAINER_DOTFILES): .buildx-initialized
 	docker images -q $(REGISTRY)/$(BIN):$(TAG) > $@
 	echo
 
+login: # @HELP configures docker to be authenticated to the defined registry
+	docker login $(REGISTRY)       \
+	    -u "$(REGISTRY_USERNAME)"  \
+	    -p "$(REGISTRY_PASSWORD)"
+
 push: # @HELP pushes the container for one platform ($OS/$ARCH) to the defined registry
 push: container
 	for bin in $(BINS); do                     \

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ BASE_IMAGE ?= gcr.io/distroless/static
 # Where to push the docker images.
 REGISTRY ?= example.com
 
+# Credentials to access the registry.
+REGISTRY_USERNAME ?= oauth2accesstoken
+REGISTRY_PASSWORD ?= $$(gcloud auth print-access-token)
+
 # This version-strategy uses git tags to set the version string
 VERSION ?= $(shell git describe --tags --always --dirty)
 #
@@ -332,8 +336,8 @@ manifest-list: all-push
 	for bin in $(BINS); do                                    \
 	    platforms=$$(echo $(ALL_PLATFORMS) | sed 's/ /,/g');  \
 	    bin/tools/manifest-tool                               \
-	        --username=oauth2accesstoken                      \
-	        --password=$$(gcloud auth print-access-token)     \
+	        --username="$(REGISTRY_USERNAME)"                 \
+	        --password="$(REGISTRY_PASSWORD)"                 \
 	        push from-args                                    \
 	        --platforms "$$platforms"                         \
 	        --template $(REGISTRY)/$$bin:$(VERSION)__OS_ARCH  \


### PR DESCRIPTION
This only takes effect on "Releases" creation, so it won't happen on thockin/go-build-template, but this would be a good example and starting point for people using this template and GitHub-ops.

See https://github.com/jingyuanliang/go-build-template/releases and https://github.com/jingyuanliang?tab=packages&repo_name=go-build-template as a showcase of execution.