### PR TITLE
Add "Run tools" workflow to prevent tools breakage from version bumps

### DIFF
--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -1,0 +1,18 @@
+name: Run tools
+
+on: [ push, pull_request ]
+
+jobs:
+  tools:
+    strategy:
+      matrix:
+        go-version: [ "1.20", "1.21" ]
+        platform: [ "ubuntu-latest" ]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Run go-licenses
+      run: make .licenses GO_VERSION=${{ matrix.go-version }}
+    - name: Build manifest-tool
+      run: make manifest-list BINS= GO_VERSION=${{ matrix.go-version }}


### PR DESCRIPTION
go-licenses is already practiced by regular builds, but manifest-tool can't build without directories created, and during regular execution they're created when building binaries, while we're skipping it here.

Let's explicitly run go-licenses to get them created here, and this could also provide a clearer signal on go-licenses itself.

The purpose of this is to prevent https://github.com/thockin/go-build-template/issues/102. The failed check execution is due to https://github.com/thockin/go-build-template/issues/102.