### PR TITLE
Bump Golang to 1.22

### DIFF
--- a/.github/workflows/crossbuild.yaml
+++ b/.github/workflows/crossbuild.yaml
@@ -6,7 +6,7 @@ jobs:
   crossbuild:
     strategy:
       matrix:
-        go-version: [ "1.20", "1.21" ]
+        go-version: [ "1.21", "1.22" ]
         platform: [ "ubuntu-latest" ]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ "1.20", "1.21" ]
+        go-version: [ "1.21", "1.22" ]
         platform: [ "ubuntu-latest" ]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -6,7 +6,7 @@ jobs:
   tools:
     strategy:
       matrix:
-        go-version: [ "1.20", "1.21" ]
+        go-version: [ "1.21", "1.22" ]
         platform: [ "ubuntu-latest" ]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -59,12 +59,12 @@ MAKEFLAGS += --warn-undefined-variables
 .SUFFIXES:
 
 # Used internally.  Users should pass GOOS and/or GOARCH.
-OS := $(if $(GOOS),$(GOOS),$(shell go env GOOS))
-ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))
+OS := $(if $(GOOS),$(GOOS),$(shell GOTOOLCHAIN=local go env GOOS))
+ARCH := $(if $(GOARCH),$(GOARCH),$(shell GOTOOLCHAIN=local go env GOARCH))
 
 TAG := $(VERSION)__$(OS)_$(ARCH)
 
-GO_VERSION := 1.21
+GO_VERSION := 1.22
 BUILD_IMAGE := golang:$(GO_VERSION)-alpine
 
 BIN_EXTENSION :=

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/thockin/go-build-template
 
-go 1.21
+go 1.22


### PR DESCRIPTION
Also set GOTOOLCHAIN=local on the go command inside Makefile so it doesn't try to download a different go toolchain based on go.mod just to extract GOOS and GOARCH, if the local toolchain doesn't match go.mod.