### PR TITLE
Fix Docker warning `LegacyKeyValueFormat`

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -34,6 +34,6 @@ COPY bin/{ARG_OS}_{ARG_ARCH}/{ARG_BIN} /{ARG_BIN}
 
 # This would be nicer as `nobody:nobody` but distroless has no such entries.
 USER 65535:65535
-ENV HOME /
+ENV HOME=/
 
 ENTRYPOINT ["/{ARG_BIN}"]


### PR DESCRIPTION
`"ENV key=value" should be used instead of legacy "ENV key value" format` per https://docs.docker.com/reference/build-checks/legacy-key-value-format/ .